### PR TITLE
docs: add JSDoc comments and enhance documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,11 +9,12 @@ A set of ready-to-use RegExp constants for parsing and extracting elements from 
 
 ## Features
 
-- 17 regex patterns covering all common Markdown elements
+- 20 regex patterns covering all common Markdown elements
 - Cross-platform support (Windows `\r\n` and Unix `\n` line endings)
 - Zero runtime dependencies
 - TypeScript definitions included
 - Lightweight (~2 KB)
+- JSDoc comments for IDE autocomplete
 
 ## Installation
 
@@ -41,25 +42,27 @@ import { REGEXP_HEADER, REGEXP_LINK } from 'markdown-regex';
 
 ## API Reference
 
-| Export | Description | Matches |
-|--------|-------------|---------|
-| `REGEXP_HEADER` | Markdown headers | `# H1`, `## H2`, `### H3` |
-| `REGEXP_IMAGE` | Image syntax | `![alt](url)` |
-| `REGEXP_LINK` | Link syntax | `[text](url)` |
-| `REGEXP_STRONG` | Bold text | `**bold**`, `__bold__` |
-| `REGEXP_EM` | Italic/emphasis | `*italic*`, `_italic_` |
-| `REGEXP_DEL` | Strikethrough | `~~deleted~~` |
-| `REGEXP_CODE` | Inline code | `` `code` `` |
-| `REGEXP_Q` | Quoted text | `:"quoted":` |
-| `REGEXP_BLOCKQUOTE` | Blockquotes | `> quote` |
-| `REGEXP_HR` | Horizontal rules | `-----` (5+ dashes) |
-| `REGEXP_PARAGRAPH` | Paragraphs | Block of text between newlines |
-| `REGEXP_BR` | Line breaks | Two or more consecutive newlines |
-| `REGEXP_EMPTY_BLOCKQUOTE` | Consecutive blockquote HTML tags | `</blockquote><blockquote>` |
-| `REGEXP_UL_LIST` | Unordered list items | `* item` |
-| `REGEXP_OL_LIST` | Ordered list items | `1. item` |
-| `REGEXP_EMPTY_UL` | Consecutive unordered list HTML tags | `</ul><ul>` |
-| `REGEXP_EMPTY_OL` | Consecutive ordered list HTML tags | `</ol><ol>` |
+| Export | Description | Pattern | Matches |
+|--------|-------------|---------|--------|
+| `REGEXP_HEADER` | All markdown headers | `/\n(#+).*/g` | `# H1`, `## H2`, `### H3` |
+| `REGEXP_H2` | Level 2 headers only | `/^## (.*$)/gim` | `## Heading 2` |
+| `REGEXP_H3` | Level 3 headers only | `/^### (.*$)/gim` | `### Heading 3` |
+| `REGEXP_IMAGE` | Image syntax | `/!\[([^\[]+)\]\(([^\)]+)\)/g` | `![alt](url)` |
+| `REGEXP_LINK` | Link syntax | `/\[([^\[]+)\]\(([^\)]+)\)/g` | `[text](url)` |
+| `REGEXP_STRONG` | Bold text | `/(\*\*|__)(.*?)(\*?)\1/g` | `**bold**`, `__bold__` |
+| `REGEXP_EM` | Italic/emphasis | `/(\s\|>)(\*\|_)(.*?)\2(\s\|<)/g` | `*italic*`, `_italic_` |
+| `REGEXP_DEL` | Strikethrough | `/\~\~(.*?)\~\~/g` | `~~deleted~~` |
+| `REGEXP_CODE` | Inline code | `/`(.*?)`/g` | `` `code` `` |
+| `REGEXP_Q` | Quoted text | `/\:"(.*?)":/g` | `::"quoted":`  |
+| `REGEXP_BLOCKQUOTE` | Blockquotes | `/\n(&gt;\|\\>).*/g` | `> quote` |
+| `REGEXP_HR` | Horizontal rules | `/\n-{5,}/g` | `-----` (5+ dashes) |
+| `REGEXP_PARAGRAPH` | Paragraphs | `/\n(.+?)\n/g` | Block of text between newlines |
+| `REGEXP_BR` | Line breaks | `/((\n){2,})/g` | Two or more consecutive newlines |
+| `REGEXP_EMPTY_BLOCKQUOTE` | Consecutive blockquote HTML tags | `/<\/blockquote><blockquote>/g` | `</blockquote><blockquote>` |
+| `REGEXP_UL_LIST` | Unordered list items | `/\n(((\s{4})?\*(.*?)\n){1,})/g` | `* item` |
+| `REGEXP_OL_LIST` | Ordered list items | `/\n[0-9]+\\.(.*)./g` | `1. item` |
+| `REGEXP_EMPTY_UL` | Consecutive unordered list HTML tags | `/<\/ul>\s?<ul>/g` | `</ul><ul>` |
+| `REGEXP_EMPTY_OL` | Consecutive ordered list HTML tags | `/<\/ol>\s?<ol>/g` | `</ol><ol>` |
 
 ## Usage Examples
 
@@ -68,44 +71,152 @@ import { REGEXP_HEADER, REGEXP_LINK } from 'markdown-regex';
 ```javascript
 import { REGEXP_LINK } from 'markdown-regex';
 
-const markdown = 'Visit [GitHub](https://github.com) and [npm](https://npmjs.com).';
-const matches = markdown.match(REGEXP_LINK);
-console.log(matches);
+const markdown = 'Check out [GitHub](https://github.com) and [npm](https://npmjs.com) for more info.';
+const links = markdown.match(REGEXP_LINK);
+console.log(links);
 // [ '[GitHub](https://github.com)', '[npm](https://npmjs.com)' ]
+
+// Test if a link exists
+if (REGEXP_LINK.test(markdown)) {
+  console.log('Markdown contains links');
+}
 ```
 
-### Extract headers
+### Extract and parse headers
 
 ```javascript
-import { REGEXP_HEADER } from 'markdown-regex';
+import { REGEXP_HEADER, REGEXP_H2 } from 'markdown-regex';
 
-const markdown = '\n# Title\n## Subtitle\n### Section';
-const matches = markdown.match(REGEXP_HEADER);
-console.log(matches);
-// [ '\n# Title', '\n## Subtitle', '\n### Section' ]
+const markdown = `
+# Main Title
+## Section One
+### Subsection
+## Section Two
+`;
+
+// Get all headers with their levels
+const allHeaders = markdown.match(REGEXP_HEADER);
+console.log(allHeaders);
+// [ '\n# Main Title', '\n## Section One', '\n### Subsection', '\n## Section Two' ]
+
+// Get only level 2 headers
+const h2Headers = markdown.match(REGEXP_H2);
+console.log(h2Headers);
+// [ '## Section One', '## Section Two' ]
 ```
 
-### Extract images
+### Find and replace bold text
+
+```javascript
+import { REGEXP_STRONG } from 'markdown-regex';
+
+const markdown = 'This is **important** and __really important__.';
+
+// Find all bold text
+const bold = markdown.match(REGEXP_STRONG);
+console.log(bold);
+// [ '**important**', '__really important__' ]
+
+// Remove markdown bold formatting
+const plainText = markdown.replace(REGEXP_STRONG, '$2');
+console.log(plainText);
+// 'This is important and really important.'
+```
+
+### Extract images and build image gallery
 
 ```javascript
 import { REGEXP_IMAGE } from 'markdown-regex';
 
-const markdown = 'Here is an ![example image](https://example.com/img.png).';
-const matches = markdown.match(REGEXP_IMAGE);
-console.log(matches);
-// [ '![example image](https://example.com/img.png)' ]
+const markdown = `
+Here's a photo: ![sunset](./sunset.jpg)
+And another: ![mountain](./mountain.png)
+`;
+
+const images = markdown.match(REGEXP_IMAGE);
+console.log(images);
+// [ '![sunset](./sunset.jpg)', '![mountain](./mountain.png)' ]
+
+// Extract image URLs
+const imageUrls = [];
+let match;
+const regex = /!\[([^\[]+)\]\(([^\)]+)\)/g;
+while ((match = regex.exec(markdown)) !== null) {
+  imageUrls.push({ alt: match[1], url: match[2] });
+}
+console.log(imageUrls);
+// [ { alt: 'sunset', url: './sunset.jpg' }, { alt: 'mountain', url: './mountain.png' } ]
+```
+
+### Parse list items
+
+```javascript
+import { REGEXP_UL_LIST, REGEXP_OL_LIST } from 'markdown-regex';
+
+const markdown = `
+* First item
+* Second item
+* Third item
+
+1. First step
+2. Second step
+3. Third step
+`;
+
+const ulItems = markdown.match(REGEXP_UL_LIST);
+const olItems = markdown.match(REGEXP_OL_LIST);
+
+console.log('Unordered lists:', ulItems);
+console.log('Ordered lists:', olItems);
+```
+
+### Find paragraphs and blockquotes
+
+```javascript
+import { REGEXP_PARAGRAPH, REGEXP_BLOCKQUOTE } from 'markdown-regex';
+
+const markdown = `
+First paragraph here.
+Still in first paragraph.
+
+Second paragraph after blank line.
+
+> This is a blockquote
+> It can span multiple lines
+`;
+
+const paragraphs = markdown.match(REGEXP_PARAGRAPH);
+const blockquotes = markdown.match(REGEXP_BLOCKQUOTE);
+
+console.log('Paragraphs:', paragraphs?.length);
+console.log('Blockquotes:', blockquotes?.length);
 ```
 
 See [`examples/basic-usage.js`](examples/basic-usage.js) for a more comprehensive demonstration.
+
+## Regex Patterns Reference
+
+For detailed regex pattern documentation, refer to the [API Reference](#api-reference) table above which includes the actual regex source for each pattern.
+
+### Platform-Aware Patterns
+
+Several patterns (`REGEXP_HEADER`, `REGEXP_BLOCKQUOTE`, `REGEXP_HR`, `REGEXP_BR`, `REGEXP_PARAGRAPH`, `REGEXP_UL_LIST`, `REGEXP_OL_LIST`) automatically adapt to your platform's line ending convention:
+- **Windows**: Uses `\r\n`
+- **Unix/Linux/macOS**: Uses `\n`
+
+This ensures reliable pattern matching regardless of where your code runs.
 
 ## TypeScript Support
 
 TypeScript definitions are included. No `@types/` package is needed:
 
 ```typescript
-import { REGEXP_LINK, REGEXP_HEADER } from 'markdown-regex';
+import { REGEXP_LINK, REGEXP_HEADER, REGEXP_H2 } from 'markdown-regex';
 
+const text = '# Title\n[link](url)';
 const links: RegExpMatchArray | null = text.match(REGEXP_LINK);
+const headers: RegExpMatchArray | null = text.match(REGEXP_HEADER);
+const h2Headers: RegExpMatchArray | null = text.match(REGEXP_H2);
 ```
 
 ## Contributing

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,18 @@
 export const REGEXP_HEADER: RegExp;
 
 /**
+ * Matches markdown level 2 headers (lines starting with exactly ##).
+ * Example: `## Heading 2`
+ */
+export const REGEXP_H2: RegExp;
+
+/**
+ * Matches markdown level 3 headers (lines starting with exactly ###).
+ * Example: `### Heading 3`
+ */
+export const REGEXP_H3: RegExp;
+
+/**
  * Matches markdown image syntax.
  * Example: `![alt text](https://example.com/image.png)`
  */
@@ -29,8 +41,8 @@ export const REGEXP_STRONG: RegExp;
 export const REGEXP_DEL: RegExp;
 
 /**
- * Matches quoted text using `:"..."` syntax.
- * Example: `:"quoted text":`
+ * Matches quoted text using `::"...":` syntax.
+ * Example: `::"quoted text":`
  */
 export const REGEXP_Q: RegExp;
 

--- a/src/lists/empty-ol.js
+++ b/src/lists/empty-ol.js
@@ -1,3 +1,8 @@
+/**
+ * Matches consecutive ordered list HTML tags with optional whitespace.
+ * Used to clean up redundant list HTML.
+ * Example: `</ol><ol>` or `</ol> <ol>`
+ */
 const REGEXP_EMPTY_OL = /<\/ol>\s?<ol>/g;
 
 export { REGEXP_EMPTY_OL };

--- a/src/lists/empty-ul.js
+++ b/src/lists/empty-ul.js
@@ -1,3 +1,8 @@
+/**
+ * Matches consecutive unordered list HTML tags with optional whitespace.
+ * Used to clean up redundant list HTML.
+ * Example: `</ul><ul>` or `</ul> <ul>`
+ */
 const REGEXP_EMPTY_UL = /<\/ul>\s?<ul>/g;
 
 export { REGEXP_EMPTY_UL };

--- a/src/lists/ol.js
+++ b/src/lists/ol.js
@@ -4,6 +4,12 @@ const platform = os.platform();
 
 const newLine = platform === "win32" ? "\r\n" : "\n";
 
+/**
+ * Matches ordered list items (lines starting with a number and period).
+ * Captures the list item number and content.
+ * Platform-aware: handles both Windows (\r\n) and Unix (\n) line endings.
+ * Example: `1. list item`, `2. another item`
+ */
 const REGEXP_OL_LIST = new RegExp(`${newLine}[0-9]+\\.(.*)`, "g");
 
 export { REGEXP_OL_LIST };

--- a/src/lists/ul.js
+++ b/src/lists/ul.js
@@ -4,6 +4,12 @@ const platform = os.platform();
 
 const newLine = platform === "win32" ? "\r\n" : "\n";
 
+/**
+ * Matches unordered list items (lines starting with `*`).
+ * Matches one or more consecutive list items with optional indentation.
+ * Platform-aware: handles both Windows (\r\n) and Unix (\n) line endings.
+ * Example: `* list item`
+ */
 const REGEXP_UL_LIST = new RegExp(
   `${newLine}(((\\s{4})?\\*(.*?)${newLine}){1,})`,
   "g"

--- a/src/tags/blockquote.js
+++ b/src/tags/blockquote.js
@@ -4,6 +4,12 @@ const platform = os.platform();
 
 const newLine = platform === "win32" ? "\r\n" : "\n";
 
+/**
+ * Matches blockquote lines starting with `>` or `&gt;` (HTML entity).
+ * Platform-aware: handles both Windows (\r\n) and Unix (\n) line endings.
+ * Captures the blockquote marker and content.
+ * Example: `> blockquote text`
+ */
 const REGEXP_BLOCKQUOTE = new RegExp(`${newLine}(&gt;|\\>)(.*)`, "g");
 
 export { REGEXP_BLOCKQUOTE };

--- a/src/tags/br.js
+++ b/src/tags/br.js
@@ -4,6 +4,11 @@ const platform = os.platform();
 
 const newLine = platform === "win32" ? "\r\n" : "\n";
 
+/**
+ * Matches two or more consecutive newlines (paragraph breaks).
+ * Platform-aware: handles both Windows (\r\n) and Unix (\n) line endings.
+ * Captures the consecutive newline sequence.
+ */
 const REGEXP_BR = new RegExp(`((${newLine}){2,})`, "g");
 
 export { REGEXP_BR };

--- a/src/tags/code.js
+++ b/src/tags/code.js
@@ -1,3 +1,8 @@
+/**
+ * Matches inline code using backtick delimiters.
+ * Captures the code content between single backticks.
+ * Example: `` `code` ``
+ */
 const REGEXP_CODE = /`(.*?)`/g;
 
 export { REGEXP_CODE };

--- a/src/tags/del.js
+++ b/src/tags/del.js
@@ -1,3 +1,8 @@
+/**
+ * Matches strikethrough text using `~~` delimiters.
+ * Captures the struck-through content.
+ * Example: `~~strikethrough~~`
+ */
 const REGEXP_DEL = /\~\~(.*?)\~\~/g;
 
 export { REGEXP_DEL };

--- a/src/tags/em.js
+++ b/src/tags/em.js
@@ -1,3 +1,9 @@
+/**
+ * Matches italic/emphasis text using `*` or `_` delimiters.
+ * Requires surrounding whitespace or angle brackets for context.
+ * Captures the content between delimiters.
+ * Example: `*italic*`, `_italic_`
+ */
 const REGEXP_EM = /(\s|>)(\*|_)(.*?)\2(\s|<)/g;
 
 export { REGEXP_EM };

--- a/src/tags/empty-blockquote.js
+++ b/src/tags/empty-blockquote.js
@@ -1,3 +1,8 @@
+/**
+ * Matches consecutive empty blockquote HTML tags.
+ * Used to clean up redundant blockquote HTML.
+ * Example: `</blockquote><blockquote>`
+ */
 const REGEXP_EMPTY_BLOCKQUOTE = /<\/blockquote><blockquote>/g;
 
 export { REGEXP_EMPTY_BLOCKQUOTE };

--- a/src/tags/header.js
+++ b/src/tags/header.js
@@ -4,9 +4,23 @@ const platform = os.platform();
 
 const newLine = platform === "win32" ? "\r\n" : "\n";
 
+/**
+ * Matches markdown headers (lines starting with one or more # characters).
+ * Captures header level and content across all heading levels.
+ * Example: `# Heading 1`, `## Heading 2`, `### Heading 3`
+ */
 const REGEXP_HEADER = new RegExp(`${newLine}(#+)(.*)`, "g");
 
+/**
+ * Matches markdown level 2 headers (lines starting with exactly ##).
+ * Example: `## Heading 2`
+ */
 const REGEXP_H2 = /^## (.*$)/gim;
+
+/**
+ * Matches markdown level 3 headers (lines starting with exactly ###).
+ * Example: `### Heading 3`
+ */
 const REGEXP_H3 = /^### (.*$)/gim;
 
 export { REGEXP_HEADER, REGEXP_H2, REGEXP_H3 };

--- a/src/tags/hr.js
+++ b/src/tags/hr.js
@@ -4,6 +4,11 @@ const platform = os.platform();
 
 const newLine = platform === "win32" ? "\r\n" : "\n";
 
+/**
+ * Matches horizontal rule lines (5 or more dashes).
+ * Platform-aware: handles both Windows (\r\n) and Unix (\n) line endings.
+ * Example: `-----`
+ */
 const REGEXP_HR = new RegExp(`${newLine}-{5,}`, "g");
 
 export { REGEXP_HR };

--- a/src/tags/image.js
+++ b/src/tags/image.js
@@ -1,3 +1,8 @@
+/**
+ * Matches markdown image syntax with alt text and URL.
+ * Captures both the alt text and the image URL.
+ * Example: `![alt text](https://example.com/image.png)`
+ */
 const REGEXP_IMAGE = /!\[([^\[]+)\]\(([^\)]+)\)/g;
 
 export { REGEXP_IMAGE };

--- a/src/tags/link.js
+++ b/src/tags/link.js
@@ -1,3 +1,8 @@
+/**
+ * Matches markdown link syntax with text and URL.
+ * Captures both the link text and the URL.
+ * Example: `[link text](https://example.com)`
+ */
 const REGEXP_LINK = /\[([^\[]+)\]\(([^\)]+)\)/g;
 
 export { REGEXP_LINK };

--- a/src/tags/paragraph.js
+++ b/src/tags/paragraph.js
@@ -4,6 +4,11 @@ const platform = os.platform();
 
 const newLine = platform === "win32" ? "\r\n" : "\n";
 
+/**
+ * Matches paragraph content between newlines.
+ * Platform-aware: handles both Windows (\r\n) and Unix (\n) line endings.
+ * Captures text content bounded by blank lines.
+ */
 const REGEXP_PARAGRAPH = new RegExp(`${newLine}(.+?)${newLine}`, "g");
 
 export { REGEXP_PARAGRAPH };

--- a/src/tags/quote.js
+++ b/src/tags/quote.js
@@ -1,3 +1,8 @@
-const REGEXP_Q = /\:\"(.*?)\"\:/g;
+/**
+ * Matches quoted text using `:"...":` syntax.
+ * Captures the quoted content.
+ * Example: `::"quoted text":`
+ */
+const REGEXP_Q = /\:"(.*?)\":/g;
 
 export { REGEXP_Q };

--- a/src/tags/strong.js
+++ b/src/tags/strong.js
@@ -1,3 +1,8 @@
+/**
+ * Matches bold/strong text using `**` or `__` delimiters.
+ * Captures the content between delimiters.
+ * Example: `**bold**`, `__bold__`
+ */
 const REGEXP_STRONG = /(\*\*|__)(.*?)(\*?)\1/g;
 
 export { REGEXP_STRONG };


### PR DESCRIPTION
- Add JSDoc comments to all regex constant definitions in source files
- Document missing exports REGEXP_H2 and REGEXP_H3 in TypeScript definitions
- Update README API table to include H2/H3 patterns
- Add regex patterns reference section showing actual pattern source
- Expand usage examples with more realistic Markdown scenarios

---
name: Pull Request
about: Propose a change to this project
---

## Summary

<!-- Briefly describe what this PR does and why -->

## Type of Change

- [ ] Bug fix
- [ ] New feature / new regex pattern
- [ ] Documentation update
- [ ] Refactor / code quality improvement
- [ ] CI/CD or tooling change

## Related Issue

Closes #<!-- issue number -->

## Checklist

- [ ] Tests have been added or updated
- [ ] All tests pass (`npm test`)
- [ ] Linting passes (`npm run lint`)
- [ ] `README.md` has been updated (if applicable)
- [ ] `CHANGELOG.md` has been updated under `[Unreleased]`
- [ ] TypeScript definitions (`src/index.d.ts`) have been updated (if a new pattern was added)

## [Linkedin page of LLazyEmail](https://www.linkedin.com/company/llazyemail/)
