### PR TITLE
ci: GitHub Action for publishing to npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,40 +1,68 @@
-# Publish to npm when a GitHub Release is created
-name: Node.js Package
+# Publish markdown-regex to npm when a GitHub Release is published.
+#
+# Setup (once):
+#   1. Create an npm Access Token with publish rights
+#      https://www.npmjs.com/settings/~/tokens
+#   2. Add it as a repository secret named `npm_token`
+#      Settings → Secrets and variables → Actions → New repository secret
+#   3. Create a GitHub Release whose tag matches package.json version
+#      (e.g. tag v2.0.0 when version is 2.0.0)
+#
+# Manual run is also available via workflow_dispatch.
+
+name: Publish to npm
 
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Pack only (do not publish)'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
 
 jobs:
-  build:
+  publish:
+    name: Build, test, and publish
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-          cache: 'npm'
-      - run: npm install
-      - run: npm run build
-      - run: npm test
+      id-token: write   # npm provenance / OIDC
 
-  publish-npm:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write # for npm provenance / OIDC if configured
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 22
           registry-url: https://registry.npmjs.org/
-          cache: 'npm'
-      - run: npm install
-      - run: npm run build
-      - run: npm publish --access public
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Preview published files
+        run: npm pack --dry-run
+
+      - name: Publish to npm
+        if: ${{ github.event_name == 'release' || inputs.dry_run != true }}
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
## What this adds

Replaces `.github/workflows/npm-publish.yml` with a single-job workflow that:

1. Checks out the repo (`actions/checkout@v7`)
2. Sets up Node 22 + npm registry (`actions/setup-node@v7`)
3. Installs, typechecks, builds, and tests
4. Previews the tarball (`npm pack --dry-run`)
5. Publishes with `npm publish --access public --provenance`

### Triggers
- **GitHub Release published** (tag should match `package.json` version, e.g. `v2.0.0`)
- **workflow_dispatch** — optional dry-run (pack only)

### Secret required
Repository secret **`npm_token`**: an npm Access Token with publish rights.

Settings → Secrets and variables → Actions → New repository secret

### How to publish 2.0.0
1. Merge this PR
2. Confirm `package.json` version is `2.0.0`
3. Create a GitHub Release tagged `v2.0.0`
4. This workflow runs and publishes to https://www.npmjs.com/package/markdown-regex